### PR TITLE
Add deleteCovers() to target specific DOM elements the user clicks an…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ viewSavedButton.addEventListener('click', showSavedView);
 homeButton.addEventListener('click', showHomeView);
 createBookButton.addEventListener('click', createUserBook);
 saveCoverButton.addEventListener('click', displaySavedCover);
-
+savedCoversSection.addEventListener('dblclick', deleteCover);
 
 // Create your event handlers and other functions here 👇
 function displayCover(randomCover, randomTitle, randomPhrase1, randomPhrase2) {
@@ -116,17 +116,24 @@ function displaySavedCover() {
   saveUserCover();
   for (var i = 0; i < savedCovers.length; i++) {
     savedCoversSection.insertAdjacentHTML('afterbegin',`
-    <section class="mini-cover" id="${savedCovers[i].id}">
-      <img class="cover-image" src=${savedCovers[i].cover}>
-      <h2 class="cover-title">${savedCovers[i].title}</h2>
-      <h3 class="tagline">A tale of <span>${savedCovers[i].tagline1}</span> and <span>${savedCovers[i].tagline2}</span></h3>
-      <img class="overlay" src="./assets/overlay.png">
+    <section class="mini-cover">
+      <img class="cover-image" src=${savedCovers[i].cover} id="${savedCovers[i].id}">
+      <h2 class="cover-title" id="${savedCovers[i].id}">${savedCovers[i].title}</h2>
+      <h3 class="tagline" id="${savedCovers[i].id}">A tale of <span>${savedCovers[i].tagline1}</span> and <span>${savedCovers[i].tagline2}</span></h3>
+      <img class="overlay" src="./assets/overlay.png" id="${savedCovers[i].id}">
     </section>`
     );
   }
-// use the savedUserCover function
-// display on the DOM
-// All saved covers
+};
+
+function deleteCover() {
+  var coverIdentity = event.target.id;
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (coverIdentity === `${savedCovers[i].id}`) {
+      savedCovers.splice(i, 1);
+    }
+  }
+  displaySavedCover();
 }
 
 // We've provided one function to get you started


### PR DESCRIPTION
What’s this PR do?
* Add id attributes to the DOM
* Listens for the user to double-click in the saved covers section
* Fires function to delete cover related to the id of the cover instance on the double-click

Where should the reviewer start?
* Notice the event listener attached to the savedCoversSection
* Go down to the displaySavedCovers() and deleteSavedCover() and notice how the two are intertwined.

How should this be manually tested?
* This could be tested by deploying the site
  * Saving some covers and viewing the saved covers
  * Choose a cover to delete and double click on it

Any background context you want to provide?
* Heavy on event delegation and bubbling.

What are the relevant tickets?
N/A

Screenshots (if appropriate)